### PR TITLE
feat: 대시보드 페이지, 즐겨찾기 페이지 최적화

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -59,7 +59,7 @@
       "description": "AI 기반 주식 여론 분석 서비스"
     }
     </script>
-    <script type="module" crossorigin src="/assets/index-DCGwPsg4.js"></script>
+    <script type="module" crossorigin src="/assets/index-Cs9EYWtZ.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-9ZLbFgwc.css">
   </head>
   <body>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { auth } from '../firebase';
 import { getRealStockData, getLatestDate } from '../services/realDataService';
-import { addToFavorites, removeFromFavorites, isSectorFavorite } from '../services/favoriteService';
+import { addToFavorites, removeFromFavorites, getUserFavorites } from '../services/favoriteService';
 import { getSectorIconPath } from '../services/sectorIconService';
 import Header from './Header';
 import Footer from './Footer';
@@ -121,18 +121,19 @@ const Dashboard: React.FC = () => {
     }
   }, [location.state, navigate, location.pathname]);
 
-  // 즐겨찾기 상태 초기화
+  // 즐겨찾기 상태 초기화 (N+1 쿼리 최적화: 1번의 쿼리로 모든 즐겨찾기 조회)
   const initializeFavoriteStates = async (stocksData: StockItem[]) => {
     if (!user) return stocksData;
-    
-    const stocksWithFavorites = await Promise.all(
-      stocksData.map(async (stock) => {
-        const isFav = await isSectorFavorite(stock.id);
-        return { ...stock, isFavorite: isFav };
-      })
-    );
-    
-    return stocksWithFavorites;
+
+    // 즐겨찾기 목록을 한 번만 조회
+    const userFavorites = await getUserFavorites();
+    const favoriteIds = new Set(userFavorites.map(f => f.sectorId));
+
+    // 메모리에서 매칭
+    return stocksData.map(stock => ({
+      ...stock,
+      isFavorite: favoriteIds.has(stock.id)
+    }));
   };
 
   // POST 데이터를 기반으로 데이터 로딩

--- a/src/components/Favorites.tsx
+++ b/src/components/Favorites.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { auth } from '../firebase';
 import { getRealStockData, getLatestDate } from '../services/realDataService';
-import { getUserFavorites, removeFromFavorites, isSectorFavorite, type FavoriteSector } from '../services/favoriteService';
+import { getUserFavorites, removeFromFavorites, type FavoriteSector } from '../services/favoriteService';
 import { getSectorIconPath } from '../services/sectorIconService';
 import Header from './Header';
 import Footer from './Footer';
@@ -141,20 +141,16 @@ const Favorites: React.FC = () => {
     }
   }, [location.state, navigate, location.pathname]);
 
-  // 즐겨찾기 상태 초기화 함수
-  const initializeFavoriteStates = async (stockData: StockItem[]) => {
-    try {
-      const stocksWithFavorites = await Promise.all(
-        stockData.map(async (stock) => {
-          const isFavorite = await isSectorFavorite(stock.id);
-          return { ...stock, isFavorite };
-        })
-      );
-      return stocksWithFavorites;
-    } catch (error) {
-      console.error('즐겨찾기 상태 초기화 오류:', error);
-      return stockData;
-    }
+  // 즐겨찾기 상태 초기화 함수 (N+1 쿼리 최적화: 이미 로드된 즐겨찾기 목록 활용)
+  const initializeFavoriteStates = (stockData: StockItem[], favoritesList: FavoriteSector[]) => {
+    // 이미 로드된 즐겨찾기 목록에서 ID Set 생성
+    const favoriteIds = new Set(favoritesList.map(f => f.sectorId));
+
+    // 메모리에서 매칭
+    return stockData.map(stock => ({
+      ...stock,
+      isFavorite: favoriteIds.has(stock.id)
+    }));
   };
 
   // POST 데이터를 기반으로 데이터 로딩
@@ -207,18 +203,18 @@ const Favorites: React.FC = () => {
       favoriteIds.includes(stock.id) || favoriteNames.includes(stock.sector)
     );
     
-    // 즐겨찾기 상태 초기화
-    const stocksWithFavorites = await initializeFavoriteStates(favoriteStocks);
+    // 즐겨찾기 상태 초기화 (이미 로드된 favoritesList 활용)
+    const stocksWithFavorites = initializeFavoriteStates(favoriteStocks, favoritesList);
     setStocks(stocksWithFavorites);
     stocksRef.current = stocksWithFavorites;
-    
+
     // 오류 메시지 설정 (즐겨찾기된 섹터가 없는 경우에만)
     if (favoriteStocks.length === 0) {
       setError('즐겨찾기된 섹터가 없습니다.');
     } else {
       setError('');
     }
-    
+
     console.log('POST 데이터 로딩 완료:', stocksWithFavorites);
   };
 
@@ -328,14 +324,14 @@ const Favorites: React.FC = () => {
       console.log('즐겨찾기 이름 목록:', favoriteNames);
       
       // ID와 이름 모두로 필터링 (realDataService에서 id가 실제로는 섹터 이름임)
-      const favoriteStocks = realStockData.filter(stock => 
+      const favoriteStocks = realStockData.filter(stock =>
         favoriteIds.includes(stock.id) || favoriteNames.includes(stock.sector)
       );
       console.log('필터링된 즐겨찾기 데이터:', favoriteStocks.length, '개');
       console.log('필터링된 섹터들:', favoriteStocks.map(s => s.sector));
-      
-      // 즐겨찾기 상태 초기화
-      const stocksWithFavorites = await initializeFavoriteStates(favoriteStocks);
+
+      // 즐겨찾기 상태 초기화 (이미 로드된 favorites 활용)
+      const stocksWithFavorites = initializeFavoriteStates(favoriteStocks, favorites);
       setStocks(stocksWithFavorites);
       stocksRef.current = stocksWithFavorites;
       


### PR DESCRIPTION
최적화 요약
Dashboard.tsx와 Favorites.tsx 모두 동일한 최적화 적용:
변경 전 (N+1 쿼리 문제)

// 각 섹터마다 개별 DB 쿼리 실행 (25개 섹터 = 25개 쿼리)
const stocksWithFavorites = await Promise.all(
  stockData.map(async (stock) => {
    const isFavorite = await isSectorFavorite(stock.id);
    return { ...stock, isFavorite };
  })
);
변경 후 (1번 쿼리 + 메모리 매칭)

// 즐겨찾기 목록을 한 번만 조회하고 Set으로 O(1) 검색
const initializeFavoriteStates = (stockData, favoritesList) => {
  const favoriteIds = new Set(favoritesList.map(f => f.sectorId));
  return stockData.map(stock => ({
    ...stock,
    isFavorite: favoriteIds.has(stock.id)
  }));
};
성능 개선 효과
DB 쿼리 수: 25개 → 1개 (96% 감소)
네트워크 지연: 개별 쿼리별 latency 누적 제거
검색 복잡도: O(N) 쿼리 → O(1) Set 검색